### PR TITLE
- Added support for new parameter max_latest_age (BRAINSTORM-2225)

### DIFF
--- a/querydata/Engine.cpp
+++ b/querydata/Engine.cpp
@@ -30,6 +30,8 @@
 #include <ogr_spatialref.h>
 #include <system_error>
 
+#define CHECK_LATEST_MODEL_AGE true
+
 namespace
 {
 auto badcoord = std::make_pair(std::numeric_limits<double>::quiet_NaN(),
@@ -473,7 +475,8 @@ Producer Engine::find(double lon,
                                      lat,
                                      maxdist,
                                      usedatamaxdistance,
-                                     leveltype);
+                                     leveltype,
+									 CHECK_LATEST_MODEL_AGE);
   }
   catch (...)
   {

--- a/querydata/Producer.cpp
+++ b/querydata/Producer.cpp
@@ -79,6 +79,9 @@ ProducerConfig parse_producerinfo(const Producer &producer, const libconfig::Set
       else if (name == "max_age")
         pinfo.max_age = Fmi::TimeParser::parse_duration(setting[i]).total_seconds();
 
+      else if (name == "max_latest_age")
+        pinfo.max_latest_age = Fmi::TimeParser::parse_duration(setting[i]).total_seconds();
+
       else if (name == "update_interval")
         pinfo.update_interval = Fmi::TimeParser::parse_duration(setting[i]).total_seconds();
 

--- a/querydata/Producer.h
+++ b/querydata/Producer.h
@@ -67,6 +67,7 @@ struct ProducerConfig
   unsigned int update_interval = 3600;      // once per hour
   unsigned int minimum_expires = 600;       // 10 minutes
   unsigned int max_age = 0;                 // do not remove old models by default based on age
+  unsigned int max_latest_age = 0;          // do not check age of latest model by default
   double maxdistance = -1;
   bool ismultifile = false;
   bool isforecast = true;

--- a/querydata/Repository.h
+++ b/querydata/Repository.h
@@ -55,7 +55,8 @@ class Repository
                 double lat,
                 double maxdist,
                 bool usedatamaxdist,
-                const std::string& leveltype) const;
+                const std::string& leveltype,
+				bool checkLatestModelAge = false) const;
 
   OriginTimes originTimes(const Producer& producer) const;
 

--- a/smartmet-engine-querydata.spec
+++ b/smartmet-engine-querydata.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-engine-%{DIRNAME}
 Summary: SmartMet qengine engine
 Name: %{SPECNAME}
-Version: 21.12.7
+Version: 22.1.3
 Release: 1%{?dist}.fmi
 License: MIT
 Group: SmartMet/Engines
@@ -80,9 +80,13 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/smartmet/engines/%{DIRNAME}/*.h
 
 %changelog
+* Mon Jan 3 2022 Anssi Reponen <anssi.reponen@fmi.fi> - 22.1.3-1.fmi
+- Added support for new parameter max_latest_age (BRAINSTORM-2225)
+- The new parameter the maximum age of the latest querydata file, so that
+old files are not used if the latest file is missing
+
 * Tue Dec  7 2021 Andris Pavēnis <andris.pavenis@fmi.fi> 21.12.7-1.fmi
 - Update to postgresql 13 and gdal 3.3
-
 
 * Wed Nov 17 2021 Anssi Reponen <anssi.reponen@fmi.fi> - 21.11.17-1.fmi
 - Make it possible to clean validpoints directory at startup (BRAINSTORM-2186)


### PR DESCRIPTION
- The new parameter the maximum age of the latest querydata file, so that
old files are not used if the latest file is missing